### PR TITLE
Django 1.5 - DO NOT MERGE

### DIFF
--- a/deploy/manage.py
+++ b/deploy/manage.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python
-from django.core.management import execute_manager
-import imp
-try:
-    imp.find_module('settings') # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n" % __file__)
-    sys.exit(1)
-
-import settings
+import os
+import sys
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/deploy/search_settings.py
+++ b/deploy/search_settings.py
@@ -1,32 +1,32 @@
-# See: http://docs.haystacksearch.org/dev/settings.html for details
-# Many of the settings below are just their default values (to be explicit)
+SEARCH_ENGINE = None
 
-HAYSTACK_SEARCH_ENGINE = None
+try:
+	import xapian
+	SEARCH_ENGINE = {
+	    'default': {
+	        'ENGINE': 'xapian_backend.XapianEngine',
+	        'PATH': os.path.join(DATA_DIR, 'xapian_index'),
+	        'INCLUDE_SPELLING': True,
+	        'BATCH_SIZE': 100,
+	    },
+	}
 
-if HAYSTACK_SEARCH_ENGINE is None:
-    try:
-        import xapian
-        HAYSTACK_SEARCH_ENGINE = 'xapian'
-        HAYSTACK_XAPIAN_PATH = os.path.join(DATA_DIR, 'xapian_index')
-    except ImportError:
-        pass
+except ImportError:
+	import whoosh
+	SEARCH_ENGINE = {
+	    'default': {
+	        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+	        'PATH': os.path.join(DATA_DIR, 'whoosh_index'),
+	        'STORAGE': 'file',
+	        'POST_LIMIT': 128 * 1024 * 1024,
+	        'INCLUDE_SPELLING': True,
+	        'BATCH_SIZE': 100,
+	    },
+	}
 
-if HAYSTACK_SEARCH_ENGINE is None:
-    try:
-        import whoosh
-        HAYSTACK_SEARCH_ENGINE = 'whoosh'
-        HAYSTACK_WHOOSH_PATH = os.path.join(DATA_DIR, 'whoosh_index')
-    except ImportError:
-        pass
-
-if HAYSTACK_SEARCH_ENGINE is None:
-    raise RuntimeError("Neither xapian nor whoosh is installed")
-
-HAYSTACK_SITECONF = 'scipy_central.search_sites'
+HAYSTACK_CONNECTIONS = SEARCH_ENGINE
 HAYSTACK_DEFAULT_OPERATOR = 'AND'
-HAYSTACK_INCLUDE_SPELLING = True
 HAYSTACK_SEARCH_RESULTS_PER_PAGE = SPC['entries_per_page']
-HAYSTACK_BATCH_SIZE = 100
 HAYSTACK_ITERATOR_LOAD_PER_QUERY = 10
 HAYSTACK_LIMIT_TO_REGISTERED_MODELS = True
 HAYSTACK_SILENTLY_FAIL = True

--- a/deploy/settings.py
+++ b/deploy/settings.py
@@ -260,6 +260,12 @@ LOGGING = {
         },
     },
 
+    'filters': {
+         'require_debug_false': {
+             '()': 'django.utils.log.RequireDebugFalse'
+         }
+     },
+
     'handlers': {
         'null': {
             'level':'DEBUG',
@@ -274,6 +280,7 @@ LOGGING = {
 
         'mail_admins': {
             'level': 'ERROR',
+            'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler'
         },
 

--- a/deploy/settings.py
+++ b/deploy/settings.py
@@ -152,8 +152,6 @@ INSTALLED_APPS = (
     'scipy_central.feeds',
 )
 
-# Authentication related:
-AUTH_PROFILE_MODULE = 'person.UserProfile'
 # Link the user is redirected to if not logged in and they try to perform
 # a function that only logged in users can do
 LOGIN_URL = '/user/login/'

--- a/deploy/settings.py
+++ b/deploy/settings.py
@@ -69,11 +69,6 @@ STATIC_ROOT = os.path.join(DATA_DIR, 'static')
 # Example: "http://media.lawrence.com/static/"
 STATIC_URL = '/static/'
 
-# URL prefix for admin static files -- CSS, JavaScript and images.
-# Make sure to use a trailing slash.
-# Examples: "http://foo.com/static/admin/", "/static/admin/".
-ADMIN_MEDIA_PREFIX = '/static/admin/'
-
 # Additional locations of static files
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'media'),

--- a/deploy/settings.py
+++ b/deploy/settings.py
@@ -108,7 +108,10 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
 )
 
-ROOT_URLCONF = 'urls'
+ROOT_URLCONF = 'deploy.urls'
+
+# Python dotted path to the WSGI application used by Django's runserver.
+WSGI_APPLICATION = 'deploy.wsgi.application'
 
 TEMPLATE_DIRS = (
     # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".

--- a/deploy/templates/404.html
+++ b/deploy/templates/404.html
@@ -12,6 +12,6 @@
 	
 	<br>
 	
-	<p>Try <a href="{% url spc-main-page %}">searching for it</a> on the main page.</p>
+	<p>Try <a href="{% url 'spc-main-page' %}">searching for it</a> on the main page.</p>
 </div>
 {% endblock %}

--- a/deploy/templates/base-includes/footer-outside.html
+++ b/deploy/templates/base-includes/footer-outside.html
@@ -2,11 +2,11 @@
 <div class="container">
 	<footer class="footer">
 		<ul class="inline pull-left">
-			<li><a href="{% url spc-main-page %}">Home</a></li>
-			<li><a href="{% url spc-about-page %}">About</a></li>
+			<li><a href="{% url 'spc-main-page' %}">Home</a></li>
+			<li><a href="{% url 'spc-about-page' %}">About</a></li>
 			<li><a href="/licenses">Licenses</a></li>
 			<li><a href="/markup-help">Markup</a></li>
-			<li><a href="{% url spc-rss-recent-submissions %}">Feeds</a></li>
+			<li><a href="{% url 'spc-rss-recent-submissions' %}">Feeds</a></li>
 		</ul>
 		
 		<ul class="inline pull-right">

--- a/deploy/templates/base-includes/header.html
+++ b/deploy/templates/base-includes/header.html
@@ -2,19 +2,19 @@
 <div class="header">
 	<ul class="nav nav-pills pull-right">
 		<li
-		{% url spc-main-page as ref_url %}
+		{% url 'spc-main-page' as ref_url %}
 		{% if request.path == ref_url %}class="active"{% endif %}
-		><a href="{% url spc-main-page %}">Home</a></li>
+		><a href="{% url 'spc-main-page' %}">Home</a></li>
 		
 		<li
-		{% url spc-about-page as ref_url %}
+		{% url 'spc-about-page' as ref_url %}
 		{% if request.path == ref_url %}class="active"{% endif %}
-		><a href="{% url spc-about-page %}">About</a></li>
+		><a href="{% url 'spc-about-page' %}">About</a></li>
 		
 		<li class="dropdown
-		{% url spc-new-submission item_type='snippet' as ref_url1 %}
-		{% url spc-new-submission item_type='link' as ref_url2 %}
-		{% url spc-new-submission item_type='package' as ref_url3 %}
+		{% url 'spc-new-submission' item_type='snippet' as ref_url1 %}
+		{% url 'spc-new-submission' item_type='link' as ref_url2 %}
+		{% url 'spc-new-submission' item_type='package' as ref_url3 %}
 		{% if request.path == ref_url1 %}active
 		{% elif request.path == ref_url2 %}active
 		{% elif request.path == ref_url3 %}active{% endif %}">
@@ -23,15 +23,15 @@
 				<b class="caret"></b>
 			</a>
 			<ul class="dropdown-menu">
-				<li><a href="{% url spc-new-submission item_type='snippet' %}">Snippet</a></li>
-				<li><a href="{% url spc-new-submission item_type='link' %}">Link</a></li>
-				<li><a href="{% url spc-new-submission item_type='package' %}">Package</a></li>
+				<li><a href="{% url 'spc-new-submission' item_type='snippet' %}">Snippet</a></li>
+				<li><a href="{% url 'spc-new-submission' item_type='link' %}">Link</a></li>
+				<li><a href="{% url 'spc-new-submission' item_type='package' %}">Package</a></li>
 			</ul>
 		</li>
 		
 		{% if user.is_active %}
 		<li class="dropdown 
-		{% url spc-user-profile user.profile.slug as ref_url %}
+		{% url 'spc-user-profile' user.profile.slug as ref_url %}
 		{% if ref_url == request.path %}active{% endif %}">
 			<a class="dropdown-toggle" data-toggle="dropdown" href="#">
 				{{user.username}}
@@ -39,21 +39,21 @@
 			</a>
 			<ul class="dropdown-menu">
 			{% if user.username and user.profile.slug %}
-				<li><a href="{% url spc-user-profile user.profile.slug %}">Profile</a></li>
-				<li><a href="{% url auth_logout %}">Logout</a></li>
+				<li><a href="{% url 'spc-user-profile' user.profile.slug %}">Profile</a></li>
+				<li><a href="{% url 'auth_logout' %}">Logout</a></li>
 			{% endif %}
 			</ul>
 		</li>
 		{% else %}
 			<li class="
-			{% url auth_login as ref_url %}
+			{% url 'auth_login' as ref_url %}
 			{% if ref_url == request.path %}active{% endif %}">
-				<a href="{% url auth_login %}">Sign In</a>
+				<a href="{% url 'auth_login' %}">Sign In</a>
 			</li>
 		{% endif %}
 	</ul>
 	
-	<a href="{% url spc-main-page %}"><img src="{{STATIC_URL}}img/scipycentral_logo.png" style="height: 34px;"></a>
+	<a href="{% url 'spc-main-page' %}"><img src="{{STATIC_URL}}img/scipycentral_logo.png" style="height: 34px;"></a>
 </div>
 </div>
 <!--/container-->

--- a/deploy/templates/base-includes/rightsidebar.html
+++ b/deploy/templates/base-includes/rightsidebar.html
@@ -14,14 +14,14 @@
 			{% if user.id == item.created_by.id %}
 			<div class="nav-title underline-bold">Contribute</div>
 			<ul class="unstyled no-lead">
-				<li>This is your submission <a href="{% url spc-edit-submission item_id=item.entry.id rev_id=item.rev_id_human %}">want to improve it</a>?</li>
+				<li>This is your submission <a href="{% url "spc-edit-submission" item_id=item.entry.id rev_id=item.rev_id_human %}">want to improve it</a>?</li>
 			</ul>
 			{% endif %}
 
 		{% else %}
 		<div class="nav-title">Contribute</div>
 		<ul class="unstyled no-lead">
-			<li><a href="{% url spc-edit-submission item_id=item.entry.id rev_id=item.rev_id_human %}">Improve this {{item.entry.sub_type}}</a></li>
+			<li><a href="{% url "spc-edit-submission" item_id=item.entry.id rev_id=item.rev_id_human %}">Improve this {{item.entry.sub_type}}</a></li>
 		</ul>
 		{% endif %}
 
@@ -30,7 +30,7 @@
 	{% if item.entry.sub_type == "snippet" %}
 	<div class="nav-title">Software License</div>
 	<ul class="unstyled no-lead">
-		<li><span>{{item.sub_license.description|safe}} (<a href="{% url spc-about-licenses%}">More details</a>)</span></li>
+		<li><span>{{item.sub_license.description|safe}} (<a href="{% url "spc-about-licenses" %}">More details</a>)</span></li>
 	</ul>
 	{% endif %}
 	
@@ -55,7 +55,7 @@
 	<div class="nav-title">Top Tags</div>
 	<ul class="unstyled no-lead">
 		{% for item in "submission.TagCreation"|top_tags:15 %}
-		<li><a class="btn btn-mini" href="{% url spc-show-items what_view="tag" extra_info=item.tag %}">{{item.tag.name}}</a> X {{item.score}}</li>
+		<li><a class="btn btn-mini" href="{% url "spc-show-items" what_view="tag" extra_info=item.tag %}">{{item.tag.name}}</a> X {{item.score}}</li>
 		{% endfor %}
 	</ul>
 
@@ -64,16 +64,16 @@
 		{% for item in "authors"|top_authors:8 %}
 		<li><a href="{{ item.get_absolute_url }}">{{ item.user.username }}</a></li>
 		{% endfor %}
-		<li><a href="{% url spc-show-items what_view="show" extra_info="top-contributors" %}">Show All</a></li>
+		<li><a href="{% url "spc-show-items" what_view="show" extra_info="top-contributors" %}">Show All</a></li>
 	</ul>
 
 	<ul class="unstyled no-lead">
-		<li><a href="{% url spc-rss-recent-submissions %}"><img src="{{STATIC_URL}}img/feed-icon-14x14.png"> most recent submissions feed</a></li>
+		<li><a href="{% url "spc-rss-recent-submissions" %}"><img src="{{STATIC_URL}}img/feed-icon-14x14.png"> most recent submissions feed</a></li>
 		{% if not preview and item.entry %}
-		<li><a href="{% url spc-rss-submission-feed item_id=item.entry.pk %}"><img src="{{STATIC_URL}}img/feed-icon-14x14.png"> This Submission Feed</a></li>
+		<li><a href="{% url "spc-rss-submission-feed" item_id=item.entry.pk %}"><img src="{{STATIC_URL}}img/feed-icon-14x14.png"> This Submission Feed</a></li>
 		{% endif %}
 		{% if what_view == "tag" %}
-		<li><a href="{% url spc-rss-tag-feed extra_info %}"><img src="{{STATIC_URL}}img/feed-icon-14x14.png"> Recent <b>{{extra_info}}</b> submissions feed</a></li>
+		<li><a href="{% url "spc-rss-tag-feed" extra_info %}"><img src="{{STATIC_URL}}img/feed-icon-14x14.png"> Recent <b>{{extra_info}}</b> submissions feed</a></li>
 		{% endif %}
 	</ul>
 

--- a/deploy/templates/registration/activate.html
+++ b/deploy/templates/registration/activate.html
@@ -9,6 +9,6 @@
 
 <p>You supplied an invalid activation key: <b>{{activation_key}}</b></p>
 
-<p>Please request a new <a href="{% url auth_password_reset %}">password reset key</a></p>
+<p>Please request a new <a href="{% url 'auth_password_reset' %}">password reset key</a></p>
 </div>
 {% endblock %}

--- a/deploy/templates/registration/activation_complete.html
+++ b/deploy/templates/registration/activation_complete.html
@@ -10,7 +10,7 @@
 <p>Any previous code or links you have submitted will now be available for other users
 to see.</p>
 
-<p>Please <a href="{% url spc-after-sign-in %}">sign in and edit your profile</a>.</p>
+<p>Please <a href="{% url 'spc-after-sign-in' %}">sign in and edit your profile</a>.</p>
 </div>
 {% endblock %}
 

--- a/deploy/templates/registration/login.html
+++ b/deploy/templates/registration/login.html
@@ -12,7 +12,7 @@
 	</div>
 	<div class="span4">
 		<h3 class="underline">Sign In</h3>
-		<form class="form" action="{% url auth_login %}" method="post">
+		<form class="form" action="{% url 'auth_login' %}" method="post">
 		{% csrf_token %}
 			{% if form.non_field_errors %}
 			<div class="alert alert-error">
@@ -46,8 +46,8 @@
 			{% endif %}
 			
 			<button class="btn btn-primary" type="submit" name="submit">Sign in</button>
-			<a class="btn btn-success" href="{% url registration_register %}">Register</a>
-			<p class="no-lead"><a href="{% url auth_password_reset %}">Forgot your username or password?</a></p>
+			<a class="btn btn-success" href="{% url 'registration_register' %}">Register</a>
+			<p class="no-lead"><a href="{% url 'auth_password_reset' %}">Forgot your username or password?</a></p>
 		</form><!--/form-->
 	</div><!--/signin span12-->
 </div><!--/row-fluid-->

--- a/deploy/templates/registration/logout.html
+++ b/deploy/templates/registration/logout.html
@@ -7,7 +7,7 @@
 	<div class="lead">
 	<p>You have been Signed out</p>
 	
-	<p><a href="{% url auth_login %}">Sign in again</a> or go to the <a href="{% url spc-main-page %}">home page</a></p>
+	<p><a href="{% url 'auth_login' %}">Sign in again</a> or go to the <a href="{% url 'spc-main-page' %}">home page</a></p>
 	</div>
 </div>
 {% endblock %}

--- a/deploy/templates/registration/password_change_done.html
+++ b/deploy/templates/registration/password_change_done.html
@@ -7,6 +7,6 @@
 <div class="lead">
 <p>Password successfully changed</p>
 
-<p>Your password has been changed.  Continue by updating your <a href="{% url spc-user-profile-edit user.profile.slug %}">public profile</a></p>
+<p>Your password has been changed.  Continue by updating your <a href="{% url 'spc-user-profile-edit' user.profile.slug %}">public profile</a></p>
 </div>
 {% endblock %}

--- a/deploy/templates/registration/password_change_form.html
+++ b/deploy/templates/registration/password_change_form.html
@@ -47,7 +47,7 @@
 			{% endif %}
 			
 			<button class="btn btn-primary" type="submit" name="submit">Change my password</button>
-			<p class="no-lead"><a href="{% url auth_password_reset%}">Rather reset your password by email?</p>
+			<p class="no-lead"><a href="{% url 'auth_password_reset' %}">Rather reset your password by email?</p>
 		</form><!--/form-->
 	</div><!--/signin span12-->
 </div><!--/row-fluid-->

--- a/deploy/templates/registration/password_reset_confirm.html
+++ b/deploy/templates/registration/password_reset_confirm.html
@@ -58,7 +58,7 @@
 <div class="hero-unit">
 <h3>Password reset unsuccessful</h3>
 
-<p>The password reset link was invalid, possibly because it has already been used.  Please request <a href="{% url auth_password_reset %}">a new password reset</a>.</p>
+<p>The password reset link was invalid, possibly because it has already been used.  Please request <a href="{% url 'auth_password_reset' %}">a new password reset</a>.</p>
 </div>
 
 {% endif %}

--- a/deploy/templates/registration/registration_closed.html
+++ b/deploy/templates/registration/registration_closed.html
@@ -5,9 +5,9 @@
 
 {% block content %}
 <div class="lead">
-<p>New accounts are currently not permitted on <a href="{% url spc-main-page %}">SciPy Central</a></p>
+<p>New accounts are currently not permitted on <a href="{% url 'spc-main-page' %}">SciPy Central</a></p>
 
-<p>Please read our <a href="{% url spc-about-page %}">About page</a> for more information</p>
+<p>Please read our <a href="{% url 'spc-about-page' %}">About page</a> for more information</p>
 </div>
 {% endblock %}
 

--- a/deploy/templates/search/includes/main-search-box.html
+++ b/deploy/templates/search/includes/main-search-box.html
@@ -1,6 +1,6 @@
 <!--Search bar-->
 <div class="spc-searchbar">
-	<form method="get" action="{% url haystack_search %}" class="form-search input-append span12">
+	<form method="get" action="{% url 'haystack_search' %}" class="form-search input-append span12">
 		<input class="span11" id="appendInputButton" type="text" name="q" placeholder="Search here...">
 		<button type="submit" class="btn"><i class="icon-search"></i></button>
 	</form>

--- a/deploy/templates/search/includes/one-person-result.html
+++ b/deploy/templates/search/includes/one-person-result.html
@@ -16,13 +16,13 @@
 		<ul class="inline tags pull-left">
 		{% for tag in entry.interests.all %}
 			<li class="btn btn-mini">
-				<a href="{% url spc-show-items what_view="tag" extra_info=tag %}">{{tag.name}}</a>
+				<a href="{% url 'spc-show-items' what_view="tag" extra_info=tag %}">{{tag.name}}</a>
 			</li>
 		{% endfor %}
 		</ul>
 
 		<ul class="inline pull-right muted">
-			<li><small>Username: <a href="{% url spc-user-profile slug=entry.slug %}">{{entry.user.username}}</a></small></li>
+			<li><small>Username: <a href="{% url 'spc-user-profile' slug=entry.slug %}">{{entry.user.username}}</a></small></li>
 			{% if entry.country %}
 				<li><small>Country: <img class="spc-flag" src="{{STATIC_URL}}flags/flag-{{entry.country.code|lower}}.png"></small></li>
 			{% endif %}

--- a/deploy/templates/search/includes/one-search-result.html
+++ b/deploy/templates/search/includes/one-search-result.html
@@ -20,7 +20,7 @@
 
 		<ul class="inline tags pull-left">
 		{% for tag in entry.tags.all %}
-			<li class="btn btn-mini"><a href="{% url spc-show-items what_view="tag" extra_info=tag %}">{{tag.name}}</a></li>
+			<li class="btn btn-mini"><a href="{% url "spc-show-items" what_view="tag" extra_info=tag %}">{{tag.name}}</a></li>
 		{% endfor %}
 		</ul>
 
@@ -28,7 +28,7 @@
 			{% if entry.short_human_revision_string %}
 				<li><small>{{entry.short_human_revision_string|safe}}</small><li>
 			{% endif %}
-			<li><small>by <a href="{% url spc-user-profile slug=entry.created_by.profile.slug %}">{{entry.created_by.username}}</a></small></li>
+			<li><small>by <a href="{% url "spc-user-profile" slug=entry.created_by.profile.slug %}">{{entry.created_by.username}}</a></small></li>
 			<li><small>on {{ entry.date_created|date:"d F Y"}}</small></li>
 		</ul>
 	</div>

--- a/deploy/urls.py
+++ b/deploy/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
 from django.conf import settings
 
 # Uncomment the next two lines to enable the admin:

--- a/deploy/wsgi.py
+++ b/deploy/wsgi.py
@@ -1,0 +1,20 @@
+"""
+WSGI config for SciPyCentral project.
+"""
+import os
+
+# We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
+# if running multiple sites in the same mod_wsgi process. To fix this, use
+# mod_wsgi daemon mode with each site in its own daemon process, or use
+# os.environ["DJANGO_SETTINGS_MODULE"] = "myproject.settings"
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+# This application object is used by any WSGI server configured to use this
+# file. This includes Django's development server, if the WSGI_APPLICATION
+# setting points here.
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()
+
+# Apply WSGI middleware here.
+# from helloworld.wsgi import HelloWorldApplication
+# application = HelloWorldApplication(application)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django >=1.4,<1.5
+Django==1.5
 django-haystack <2.0.0
 Whoosh <2.5.0
 South

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.5
 django-haystack==2.1.0
 Whoosh==2.5.1
 South
-django-registration ==0.8
+django-registration==1.0
 django-widget-tweaks
 Sphinx
 Pygments

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==1.5
-django-haystack <2.0.0
-Whoosh <2.5.0
+django-haystack==2.1.0
+Whoosh==2.5.1
 South
 django-registration ==0.8
 django-widget-tweaks

--- a/scipy_central/feeds/feeds.py
+++ b/scipy_central/feeds/feeds.py
@@ -1,8 +1,8 @@
 # django imports
-from django.template.defaultfilters import slugify
 from django.shortcuts import get_object_or_404
 from django.contrib.syndication.views import Feed
 from django.utils.feedgenerator import Atom1Feed
+from django.utils.text import slugify
 
 # scipycentral imports
 from scipy_central.submission.models import Submission, Revision

--- a/scipy_central/feeds/urls.py
+++ b/scipy_central/feeds/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 import feeds
 
 urlpatterns = patterns('scipy_central.feeds.views',

--- a/scipy_central/pages/templates/pages/about-licenses.html
+++ b/scipy_central/pages/templates/pages/about-licenses.html
@@ -48,7 +48,7 @@
 	described above. If you prefer a different license for your code, please
 	host the code on another website
 	(e.g. GitHub, BitBucket, Google Code), and feel free to <a href="
-	{% url spc-new-submission item_type='link' %}">create a link submission</a>, rather than
+	{% url 'spc-new-submission' item_type='link' %}">create a link submission</a>, rather than
 	a code submission.
 
 	<p>Code snippets must use the CC0 license, since it does not require

--- a/scipy_central/pages/templates/pages/front-page.html
+++ b/scipy_central/pages/templates/pages/front-page.html
@@ -24,7 +24,7 @@
 		</ul>
 		{% endfor %}
 		<div class="pagination pagination-small pagination-centered">
-			<ul><li><a href="{% url spc-show-items what_view="show" extra_info="all-revisions" %}">View all</a></li></ul>
+			<ul><li><a href="{% url "spc-show-items" what_view="show" extra_info="all-revisions" %}">View all</a></li></ul>
 		</div>	
 	</div><!--/tab-pane active-->
 	
@@ -37,7 +37,7 @@
 		{% endwith %}
 		{% endfor %}
 		<div class="pagination pagination-small pagination-centered">
-			<ul><li><a href="{% url spc-show-items what_view="sort" extra_info="most-viewed" %}">View all</a></li></ul>
+			<ul><li><a href="{% url "spc-show-items" what_view="sort" extra_info="most-viewed" %}">View all</a></li></ul>
 		</div>
 	</div><!--/tab pane-->	
 </div><!--/CONTENT-->

--- a/scipy_central/pages/templates/pages/make-submission-buttons.html
+++ b/scipy_central/pages/templates/pages/make-submission-buttons.html
@@ -1,7 +1,7 @@
 {# DEPRRCATED #}
 
 <div class="spc-button-container">
-  <form method="post" action="{% url spc-new-submission %}" class="spc-new-submission-formlist">
+  <form method="post" action="{% url 'spc-new-submission' %}" class="spc-new-submission-formlist">
   {% csrf_token %}
     <ul id="spc-buttonlist">
       <li>

--- a/scipy_central/pages/urls.py
+++ b/scipy_central/pages/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('scipy_central.pages.views',
 

--- a/scipy_central/person/admin.py
+++ b/scipy_central/person/admin.py
@@ -1,22 +1,25 @@
-from django.contrib import admin
-from models import User, UserProfile
-from django.contrib.auth.signals import user_logged_in
 from django.db.models import signals
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
+from django.contrib.auth.signals import user_logged_in
+
+# scipy_central imports
+import models, views
 
 # 3rd-party ``registration`` app: connect up the signals
-import views
 from registration.signals import user_registered, user_activated
 
-class UserProfileAdmin(admin.ModelAdmin):
-    list_display = ('pk', 'user', 'is_validated', 'affiliation', 'country',
-                    'reputation', 'bio', 'uri', 'openid',
-                    'contactable_via_site', 'allow_user_to_email')
-    list_display_links = ('user',)
-    list_per_page = 1000
-    ordering = ('user',)
+class UserProfileInline(admin.StackedInline):
+    model = models.UserProfile
+    can_delete = False
+    verbose_name_plural = 'profile'
+    
+class UserAdmin(UserAdmin):
+    inlines = (UserProfileInline, )
 
-admin.site.register(UserProfile, UserProfileAdmin)
-
+admin.site.unregister(User)
+admin.site.register(User, UserAdmin)
 
 # Hook up the signals here. Doing it in models.py results in circular imports.
 user_registered.connect(views.create_new_account)

--- a/scipy_central/person/management.py
+++ b/scipy_central/person/management.py
@@ -12,19 +12,18 @@ def validate_superuser(app, created_models, verbosity, **kwargs):
     #print(app_label, app_name, app_models)
 
     if app_label == 'auth':
-        from django.conf import settings
         from django.core.exceptions import ImproperlyConfigured
         from django.db.models import get_model
         from django.contrib.auth.models import User
-        user_class = get_model(*settings.AUTH_PROFILE_MODULE.split('.', 2))
-        if not user_class:
-            raise ImproperlyConfigured('Could not get custom user model')
+        user_profile = get_model("person", "UserProfile")
+        if not user_profile:
+            raise ImproperlyConfigured('Could not get user profile model')
 
         users = User.objects.all()
         if len(users)==1 and users[0].is_superuser:
-            print('Validating superuser in the subclassed user table')
+            print('Validating superuser in the user profile table')
 
-            user = user_class.objects.create(user=users[0])
+            user = user_profile.objects.create(user=users[0])
             user.is_validated = True
             user.save()
 

--- a/scipy_central/person/models.py
+++ b/scipy_central/person/models.py
@@ -1,5 +1,5 @@
-from django.contrib.auth.models import User
 from django.db import models
+from django.contrib.auth.models import User
 from scipy_central.utils import unique_slugify
 import hashlib
 
@@ -18,8 +18,21 @@ class Country(models.Model):
 
 
 class UserProfile(models.Model):
-    # See https://docs.djangoproject.com/en/1.3/topics/auth/
+    """
+    Profile settings for `django.contrib.auth.models.User`
+    We are not using django-1.5 User profile extension feature since
+    the below settings don't belong to "authentication" part.
 
+    The UserProfile for every `User` object is created upon
+    receiving signals mentioned in `models.py`
+
+    For future (note):
+        The `openid` field can't be used for authentication
+        in case if we support openid in future!
+
+        Custom user model inherited from Abstract User class
+        has to be used
+    """
     user = models.OneToOneField(User, unique=True, related_name="profile")
 
     # Slug field

--- a/scipy_central/person/models.py
+++ b/scipy_central/person/models.py
@@ -1,71 +1,7 @@
 from django.contrib.auth.models import User
 from django.db import models
 from scipy_central.utils import unique_slugify
-from registration.backends.default import DefaultBackend
-from django.contrib.sites.models import Site
-from django.contrib.sites.models import RequestSite
-from registration import signals
-from registration.models import RegistrationProfile
 import hashlib
-
-class SciPyRegistrationBackend(DefaultBackend):
-
-    def register(self, request, **kwargs):
-        """
-        Given a username, email address and password, register a new
-        user account, which will initially be inactive.
-
-        Along with the new ``User`` object, a new
-        ``registration.models.RegistrationProfile`` will be created,
-        tied to that ``User``, containing the activation key which
-        will be used for this account.
-
-        An email will be sent to the supplied email address; this
-        email should contain an activation link. The email will be
-        rendered using two templates. See the documentation for
-        ``RegistrationProfile.send_activation_email()`` for
-        information about these templates and the contexts provided to
-        them.
-
-        After the ``User`` and ``RegistrationProfile`` are created and
-        the activation email is sent, the signal
-        ``registration.signals.user_registered`` will be sent, with
-        the new ``User`` as the keyword argument ``user`` and the
-        class of this backend as the sender.
-
-        """
-        username, email, password = kwargs['username'], kwargs['email'], kwargs['password1']
-        if Site._meta.installed:
-            site = Site.objects.get_current()
-        else:
-            site = RequestSite(request)
-
-        # We are creating a user with the same email address. We have already
-        # verified in ``forms.py`` that this isn't a mistake. Go ahead and pull
-        # the existing user from the DB and return that user instead.
-        if User.objects.filter(email__iexact=email):
-            new_user = User.objects.filter(email__iexact=email)[0]
-            new_user.username = username
-            new_user.set_password(password)
-            new_user.save()
-
-            # Resave their profile also (updates the slug)
-            new_user_profile = UserProfile.objects.get(user=new_user)
-            new_user_profile.save()
-
-            # Complete the activation email part
-            registration_profile = RegistrationProfile.objects.create_profile(new_user)
-            registration_profile.send_activation_email(site)
-        else:
-
-            new_user = RegistrationProfile.objects.create_inactive_user(\
-                                               username, email,password, site)
-
-        signals.user_registered.send(sender=self.__class__,
-                                     user=new_user,
-                                     request=request)
-        return new_user
-
 
 class Country(models.Model):
     """ Model for a country """

--- a/scipy_central/person/search_indexes.py
+++ b/scipy_central/person/search_indexes.py
@@ -1,9 +1,9 @@
-from haystack import indexes, site
+from haystack import indexes
 from models import UserProfile
 
 # SearchIndex object for each revision in the database
 
-class UserProfileIndex(indexes.RealTimeSearchIndex):
+class UserProfileIndex(indexes.SearchIndex, indexes.Indexable):
 
     # The main field to search in: see template search/indexes/person/userprofile_text.txt
     text = indexes.CharField(document=True, use_template=True)
@@ -14,7 +14,7 @@ class UserProfileIndex(indexes.RealTimeSearchIndex):
     def get_model(self):
         return UserProfile
 
-    def index_queryset(self):
+    def index_queryset(self, **kwargs):
         # The ``Revision`` model has its own managers that does the right
         # thing in calling ``all()``.
         return self.get_model().objects.filter(is_validated=True)
@@ -27,4 +27,3 @@ class UserProfileIndex(indexes.RealTimeSearchIndex):
 
         return self.prepared_data
 
-site.register(UserProfile, UserProfileIndex)

--- a/scipy_central/person/templates/person/profile.html
+++ b/scipy_central/person/templates/person/profile.html
@@ -56,7 +56,7 @@
 					<ul class="inline tags">
 					{% for tag in theuser.profile.interests.all %}
 						<li class="btn btn-mini">
-							<a href="{% url spc-show-items what_view="tag" extra_info=tag %}">{{tag.name}}</a>
+							<a href="{% url 'spc-show-items' what_view="tag" extra_info=tag %}">{{tag.name}}</a>
 						</li>
 					{% endfor %}
 					</ul>
@@ -80,8 +80,8 @@
 					<td>Settings</td>
 					<td>
 						<ul class="unstyled">
-							<li><a href="{% url auth_password_change %}">Change password</a></li>
-							<li><a href="{% url spc-user-profile-edit user.profile.slug %}">Edit profile</a></li>
+							<li><a href="{% url 'auth_password_change' %}">Change password</a></li>
+							<li><a href="{% url 'spc-user-profile-edit' user.profile.slug %}">Edit profile</a></li>
 						</ul>
 					</td>
 				</tr>

--- a/scipy_central/person/urls.py
+++ b/scipy_central/person/urls.py
@@ -1,16 +1,19 @@
-from django.conf.urls.defaults import patterns, url
-from registration.views import register
-from forms import SignUpForm
-#from models import SciPyRegistrationBackend
+from django.conf.urls.defaults import patterns, url, include
+from views import SciPyRegistrationBackend
 
 urlpatterns = patterns('scipy_central.person.views',
     # Just override ``registration`` app's URL for registration so that we
     # can provide our own form class. Everything else from that app's default
     # settings are OK for our site.
-    url(r'^register/$', register,
-                    {'backend': 'scipy_central.person.models.SciPyRegistrationBackend',
-                     'form_class': SignUpForm},
-                    name='registration_register'),
+
+    # NOTE: the {% url 'registration_register' %} template tag technically
+    # never matches with the below url Since the overridden url and built-in url
+    # happens to be same, it does not matter and we don't have to care!
+    # If we want to change the below url from register/ to something else, 
+    # `name` argument has to be changed along with template tags in all templates
+    url(r'^register/$', SciPyRegistrationBackend.as_view(), name='registration_register'),
+
+    url(r'^', include('registration.backends.default.urls')),
 
     # The page where the user is redirected to on sign in
     url(r'^profile/$', 'sign_in_landing', name='spc-after-sign-in'),

--- a/scipy_central/person/urls.py
+++ b/scipy_central/person/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 from views import SciPyRegistrationBackend
 
 urlpatterns = patterns('scipy_central.person.views',

--- a/scipy_central/person/views.py
+++ b/scipy_central/person/views.py
@@ -1,11 +1,13 @@
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+from django.contrib.sites.models import RequestSite
 from django.shortcuts import render_to_response, redirect
 from django.template import RequestContext
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
 from django.template.loader import render_to_string
 from django.db.utils import IntegrityError
-
 
 # Imports from other SciPy Central apps
 from scipy_central.pages.views import page_404_error
@@ -15,9 +17,16 @@ from scipy_central.utils import paginated_queryset, send_email
 from scipy_central.tagging.views import get_and_create_tags
 from scipy_central.pagehit.views import create_hit
 
+# 3rd party imports
+from registration.backends.default.views import RegistrationView
+from registration.models import RegistrationProfile
+from registration import signals
+
+# local package imports
 import models
 import forms
 
+# python
 import random
 import logging
 
@@ -219,3 +228,63 @@ def account_activation(user, **kwargs):
         rev.is_displayed = True
         rev.validation_hash = None
         rev.save()
+
+class SciPyRegistrationBackend(RegistrationView):
+
+    form_class = forms.SignUpForm
+
+    def register(self, request, **kwargs):
+        """
+        Given a username, email address and password, register a new
+        user account, which will initially be inactive.
+
+        Along with the new ``User`` object, a new
+        ``registration.models.RegistrationProfile`` will be created,
+        tied to that ``User``, containing the activation key which
+        will be used for this account.
+
+        An email will be sent to the supplied email address; this
+        email should contain an activation link. The email will be
+        rendered using two templates. See the documentation for
+        ``RegistrationProfile.send_activation_email()`` for
+        information about these templates and the contexts provided to
+        them.
+
+        After the ``User`` and ``RegistrationProfile`` are created and
+        the activation email is sent, the signal
+        ``registration.signals.user_registered`` will be sent, with
+        the new ``User`` as the keyword argument ``user`` and the
+        class of this backend as the sender.
+
+        """
+        username, email, password = kwargs['username'], kwargs['email'], kwargs['password1']
+        if Site._meta.installed:
+            site = Site.objects.get_current()
+        else:
+            site = RequestSite(request)
+
+        # We are creating a user with the same email address. We have already
+        # verified in ``forms.py`` that this isn't a mistake. Go ahead and pull
+        # the existing user from the DB and return that user instead.
+        if User.objects.filter(email__iexact=email):
+            new_user = User.objects.filter(email__iexact=email)[0]
+            new_user.username = username
+            new_user.set_password(password)
+            new_user.save()
+
+            # Resave their profile also (updates the slug)
+            new_user_profile = UserProfile.objects.get(user=new_user)
+            new_user_profile.save()
+
+            # Complete the activation email part
+            registration_profile = RegistrationProfile.objects.create_profile(new_user)
+            registration_profile.send_activation_email(site)
+        else:
+
+            new_user = RegistrationProfile.objects.create_inactive_user(\
+                                               username, email,password, site)
+
+        signals.user_registered.send(sender=self.__class__,
+                                     user=new_user,
+                                     request=request)
+        return new_user

--- a/scipy_central/person/views.py
+++ b/scipy_central/person/views.py
@@ -137,13 +137,13 @@ def profile_page(request, slug=None, user_id=None):
     """
     try:
         if user_id:
-            the_user = models.User.objects.get(id=user_id)
+            the_user = User.objects.get(id=user_id)
             if the_user.is_active:
                 return redirect(profile_page, the_user.profile.slug)
         elif slug is None:
             the_user = request.user
         else:
-            the_user = models.User.objects.get(profile__slug=slug)
+            the_user = User.objects.get(profile__slug=slug)
     except ObjectDoesNotExist:
         return page_404_error(request, 'No profile for that user.')
 
@@ -182,7 +182,7 @@ def create_new_account_internal(email):
     We assume the ``email`` has already been validated as an email address.
     """
     # First check if that email address have been used; return ``False``
-    previous = models.User.objects.filter(email=email)
+    previous = User.objects.filter(email=email)
     if len(previous) > 0:
         return previous[0]
 
@@ -191,7 +191,7 @@ def create_new_account_internal(email):
                              for i in range(50)])
     username = 'Unvalidated %s-%s' % (email.split('@')[0],
                                       temp_password[2:6])
-    new_user = models.User.objects.create(username=username, email=email)
+    new_user = User.objects.create(username=username, email=email)
 
     new_user.set_password(temp_password)
     new_user.is_active = False

--- a/scipy_central/rest_comments/urls.py
+++ b/scipy_central/rest_comments/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, patterns
+from django.conf.urls import url, patterns
 
 urlpatterns = patterns('scipy_central.rest_comments.views',
 

--- a/scipy_central/screenshot/urls.py
+++ b/scipy_central/screenshot/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, patterns
+from django.conf.urls import url, patterns
 
 urlpatterns = patterns('scipy_central.screenshot.views',
 

--- a/scipy_central/submission/models.py
+++ b/scipy_central/submission/models.py
@@ -3,10 +3,10 @@ import os
 from django.db import models
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.template.defaultfilters import slugify
 
 from scipy_central.person.models import User
 from scipy_central.utils import ensuredir
+from django.utils.text import slugify
 
 class Module(models.Model):
     """

--- a/scipy_central/submission/models.py
+++ b/scipy_central/submission/models.py
@@ -2,9 +2,9 @@ import os
 
 from django.db import models
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 
-from scipy_central.person.models import User
 from scipy_central.utils import ensuredir
 from django.utils.text import slugify
 

--- a/scipy_central/submission/search_indexes.py
+++ b/scipy_central/submission/search_indexes.py
@@ -1,9 +1,9 @@
-from haystack import indexes, site
+from haystack import indexes
 from models import Revision
 
 # SearchIndex object for each revision in the database
 
-class RevisionIndex(indexes.RealTimeSearchIndex):
+class RevisionIndex(indexes.SearchIndex, indexes.Indexable):
 
     # The main field to search in: see template search/indexes/submission/revision_text.txt
     text = indexes.CharField(document=True, use_template=True)#model_attr='description')
@@ -20,7 +20,7 @@ class RevisionIndex(indexes.RealTimeSearchIndex):
     def get_model(self):
         return Revision
 
-    def index_queryset(self):
+    def index_queryset(self, **kwargs):
         # The ``Revision`` model has its own managers that does the right
         # thing in calling ``all()``.
         return self.get_model().objects.all()
@@ -33,4 +33,3 @@ class RevisionIndex(indexes.RealTimeSearchIndex):
 
         return self.prepared_data
 
-site.register(Revision, RevisionIndex)

--- a/scipy_central/submission/templates/submission/item.html
+++ b/scipy_central/submission/templates/submission/item.html
@@ -30,7 +30,7 @@
 
 <dl class="dl-horizontal">
 	<dt class="muted">Submitted by</dt>
-	<dd>{% if item.entry.created_by.profile.is_validated %}<a href="{% url spc-user-profile item.entry.created_by.profile.slug %}">{{item.entry.created_by.username}}</a> on {% if item.entry.date_created %}{{item.entry.date_created|naturalday:"d F Y"}}{% else %}today{% endif %}{% else %}Your name will be here once you validate yourself by email{% endif %}</dd>
+	<dd>{% if item.entry.created_by.profile.is_validated %}<a href="{% url 'spc-user-profile' item.entry.created_by.profile.slug %}">{{item.entry.created_by.username}}</a> on {% if item.entry.date_created %}{{item.entry.date_created|naturalday:"d F Y"}}{% else %}today{% endif %}{% else %}Your name will be here once you validate yourself by email{% endif %}</dd>
 
 	{% if item.entry.sub_type == "link" %}
 	<dt class="muted">Link</dt>
@@ -43,7 +43,7 @@
 		{% if preview %}
 			<i>Links to the ZIP file contents will appear here</i>
 		{% else %}
-			<a href="{% url spc-download-submission item_id=item.entry.id rev_id=item.rev_id_human %}">File</a>
+			<a href="{% url 'spc-download-submission' item_id=item.entry.id rev_id=item.rev_id_human %}">File</a>
 		{% endif %}
 	</dd>
 	{% endif %}
@@ -54,7 +54,7 @@
 		{% if preview %}
 			<i>Links to the ZIP file contents will appear here</i>
 		{% else %}
-			<a href="{% url spc-download-submission item_id=item.entry.id rev_id=item.rev_id_human %}">All files</a>
+			<a href="{% url 'spc-download-submission' item_id=item.entry.id rev_id=item.rev_id_human %}">All files</a>
 		{% endif %}
 	</dd>
 	{% endif %}
@@ -70,7 +70,7 @@
 
 	<dt class="muted">Updated by</dt>
 	<dd>
-		{% if item.created_by.profile.is_validated %}<a href="{% url spc-user-profile item.created_by.profile.slug %}">{{item.created_by.username}}</a>{% else %}Unvalidated user{% endif %} on {% if item.date_created %}{{item.date_created|naturalday:"d F Y"}}{% else %}today{% endif %}
+		{% if item.created_by.profile.is_validated %}<a href="{% url 'spc-user-profile' item.created_by.profile.slug %}">{{item.created_by.username}}</a>{% else %}Unvalidated user{% endif %} on {% if item.date_created %}{{item.date_created|naturalday:"d F Y"}}{% else %}today{% endif %}
 	</dd>
 	{% endif %}
 
@@ -78,7 +78,7 @@
 	<dd>
 		<ul class="inline tags">
 		{% for tag in tag_list %}
-			<li class="btn btn-mini"><a href="{% url spc-show-items what_view="tag" extra_info=tag %}">{{tag.name}}</a></li>
+			<li class="btn btn-mini"><a href="{% url 'spc-show-items' what_view="tag" extra_info=tag %}">{{tag.name}}</a></li>
 		{% endfor %}
 		</ul>
 	</dd>

--- a/scipy_central/submission/templates/submission/new-item.html
+++ b/scipy_central/submission/templates/submission/new-item.html
@@ -25,7 +25,7 @@ $(function() {
 		})
 		.autocomplete({
 			source: function( request, response ) {
-				$.getJSON( "{% url spc-tagging-ajax %}", {
+				$.getJSON( "{% url 'spc-tagging-ajax' %}", {
 					term: extractLast( request.term )
 				}, response );
 			},
@@ -56,9 +56,9 @@ $(function() {
 </script>
 
 <h3 class="underline">
-{% url spc-new-submission item_type='snippet' as ref_url1 %}
-{% url spc-new-submission item_type='link' as ref_url2 %}
-{% url spc-new-submission item_type='package' as ref_url3 %}
+{% url 'spc-new-submission' item_type='snippet' as ref_url1 %}
+{% url 'spc-new-submission' item_type='link' as ref_url2 %}
+{% url 'spc-new-submission' item_type='package' as ref_url3 %}
 {% if request.path == ref_url1 %}Snippet Submission
 {% elif request.path == ref_url2 %}Link Submission
 {% elif request.path == ref_url3 %}Package Submission
@@ -100,7 +100,7 @@ $(function() {
 			<div class="controls">
 				<div class="alert alert-info help-text" id="alert-image_upload" style="display: none;">
 					<div class="close" onclick="$('#alert-image_upload').hide();">&times;</div>
-					<p><small>Please upload JPEG or PNG images. Please refer to <a href="{% url spc-markup-help %}" target="_blank">markup</a> for adding images in the description</small></p>
+					<p><small>Please upload JPEG or PNG images. Please refer to <a href="{% url 'spc-markup-help' %}" target="_blank">markup</a> for adding images in the description</small></p>
 				</div>
 				<a href="#image_upload-modal" role="button" class="btn btn-primary btn-small" data-toggle="modal">Upload Image</a>
 			</div>
@@ -123,7 +123,7 @@ $(document).ready(function() {
 	 var options = {
 		 target:    '#spc-item-upload-output-ajax-adds-it',
 		 success: function() { $('#spc-item-upload-output-ajax-adds-it').fadeIn('slow'); },
-		 url:       '{% url spc-screenshot-add %}',
+		 url:       '{% url "spc-screenshot-add" %}',
 		 type:      'post',
 		 clearForm:  true,
 		 resetForm:  true,

--- a/scipy_central/submission/templates/submission/show-tag-cloud.html
+++ b/scipy_central/submission/templates/submission/show-tag-cloud.html
@@ -8,7 +8,7 @@
 <div class="spc-page-title"><h3>All tags</h3></div>
   <div>
 	{% for item in "submission.TagCreation"|cloud:0 %}
-	  <span class="tags" style="padding: 1px;"><a href="{% url spc-show-items what_view="tag" extra_info=item.tag %}" class="spc-tag-cloud btn btn-small" style="font-size: {{item.score}}%">{{item.tag.name}}</a></span>
+	  <span class="tags" style="padding: 1px;"><a href="{% url 'spc-show-items' what_view="tag" extra_info=item.tag %}" class="spc-tag-cloud btn btn-small" style="font-size: {{item.score}}%">{{item.tag.name}}</a></span>
 	{% endfor %}
   </div>
 {% endblock %}

--- a/scipy_central/submission/templates/submission/show-top-contributors.html
+++ b/scipy_central/submission/templates/submission/show-top-contributors.html
@@ -38,7 +38,7 @@
 <ul>
   {#The ``entry`` objects must be from the ``submission.Revision`` class #}
   {% for entry in entries.object_list %}
-	<li><a href="{% url spc-user-profile slug=entry.profile.slug %}">{{entry.username}}</a>
+	<li><a href="{% url 'spc-user-profile' slug=entry.profile.slug %}">{{entry.username}}</a>
 
 	<!--Tags applied by {{entry.username}}: taglist here-->
 

--- a/scipy_central/submission/templates/submission/thank-user.html
+++ b/scipy_central/submission/templates/submission/thank-user.html
@@ -10,7 +10,7 @@
 
 <p>{{extra_message|safe}}
 
-<p>Go back to the <a href="{% url spc-main-page %}">main page</a>.
+<p>Go back to the <a href="{% url 'spc-main-page' %}">main page</a>.
 </div>
 </div>
 {% endblock %}

--- a/scipy_central/submission/urls.py
+++ b/scipy_central/submission/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, patterns
+from django.conf.urls import url, patterns
 
 urlpatterns = patterns('scipy_central.submission.views',
 

--- a/scipy_central/submission/views.py
+++ b/scipy_central/submission/views.py
@@ -3,7 +3,6 @@ from django.shortcuts import render_to_response, redirect, HttpResponse
 from django.template import RequestContext
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.template.defaultfilters import slugify
 from django.template.loader import render_to_string
 from django import template
 from django.contrib.auth.decorators import login_required
@@ -11,6 +10,7 @@ from django.contrib.sites.models import Site
 from django.utils.hashcompat import sha_constructor
 from django.core.files.uploadedfile import UploadedFile
 from django.utils.encoding import force_unicode, smart_str
+from django.utils.text import slugify
 
 # Imports from this app and other SPC apps
 from scipy_central.person.views import create_new_account_internal

--- a/scipy_central/submission/views.py
+++ b/scipy_central/submission/views.py
@@ -589,7 +589,7 @@ def new_or_edit_submission(request, item_type, bound_form=False, submission=None
         context['finish_button_text'] = 'Finish submission'
         # %% is required in below string to correctly format
         html = ("""<div id="spc-preview-edit-submit" class="spc-form">
-                <form action="{%% url spc-new-submission item_type='%s' %%}" 
+                <form action="{%% url 'spc-new-submission' item_type='%s' %%}" 
                 method="POST" enctype="multipart/form-data">\n
                 {%% csrf_token %%}\n
                 {{item.as_hidden}}

--- a/scipy_central/tagging/models.py
+++ b/scipy_central/tagging/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 
 import logging
 logger = logging.getLogger('scipycentral')

--- a/scipy_central/tagging/tests.py
+++ b/scipy_central/tagging/tests.py
@@ -13,13 +13,13 @@ class RepeatedTag(TestCase):
         """
         # Always use ``get_or_create(...)`` rather than relying on
         # ``create(...)`` to return a valid tag.
-        t1, _ = Tag.objects.get_or_create(name='testing tag')
-        t2, _ = Tag.objects.get_or_create(name='testing tag')
+        t1, _ = Tag.objects.get_or_create(name=u'testing tag')
+        t2, _ = Tag.objects.get_or_create(name=u'testing tag')
         self.assertEqual(t1.id, t2.id)
 
     def unicode_tags(self):
         self.assertRaises(ValidationError, Tag.objects.get_or_create,
-                          name='さようなら')
+                          name=u'さようなら')
 
 
 class TagParsing(TestCase):

--- a/scipy_central/tagging/urls.py
+++ b/scipy_central/tagging/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, patterns
+from django.conf.urls import url, patterns
 
 urlpatterns = patterns('scipy_central.tagging.views',
 

--- a/scipy_central/tagging/views.py
+++ b/scipy_central/tagging/views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 from django.utils import simplejson
-from django.template.defaultfilters import slugify
 from django.utils.encoding import force_unicode
+from django.utils.text import slugify
 from django.core.exceptions import ValidationError
 
 import models

--- a/scipy_central/urls.py
+++ b/scipy_central/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, include, patterns
+from django.conf.urls import url, include, patterns
 urlpatterns = patterns('scipy_central',
 
     # NOTE: internal name for front page (defined in scipy_central.pages.urls)

--- a/scipy_central/urls.py
+++ b/scipy_central/urls.py
@@ -7,7 +7,7 @@ urlpatterns = patterns('scipy_central',
     # Major pages in the site: front page, about page, search, etc
     url(r'', include('scipy_central.pages.urls')),
 
-    # User authentication and profile viewing.
+    # User registration, authentication and profile viewing.
     url(r'^user/', include('scipy_central.person.urls'), ),
 
     # Submissions: new and existing, including previous revisions
@@ -15,11 +15,6 @@ urlpatterns = patterns('scipy_central',
 
     # reST comment converted to HTML
     url(r'rest/', include('scipy_central.rest_comments.urls')),
-
-    # Django-registration: new accounts, password resets, etc
-    # NOTE: the default backend is overriden ONLY for new account registration
-    # in scipy_central.person.urls
-    (r'^user/', include('registration.backends.default.urls')),
 
     # Tagging
     (r'^tagging/', include('scipy_central.tagging.urls')),

--- a/scipy_central/utils/__init__.py
+++ b/scipy_central/utils/__init__.py
@@ -1,4 +1,4 @@
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 from django.conf import settings
 from django.core.mail import send_mail, BadHeaderError
 from django.core.paginator import Paginator, InvalidPage, EmptyPage


### PR DESCRIPTION
The below are the  changes made (some minor changes might have been missed but can be found clearly in commit messages)
1. Upgrade `{% url %}` template tag
2. Use django-haystack 2.1.0, xapian-haystack 2.0.0, Whoosh 2.5.1 -- make respective changes in `search_settings.py` and `search_indexes.py`
3. Use django-registration 1.0 -- Also move `registration.backends.default.urls` from `scipy_central.urls` to `scipy_central.person.urls`
4. DVCS (windows specific) error fixed
5. Use django transaction middleware, clickjacking middleware
6. Make `pages.views.page_404_error` default 404 handler
7. Add wsgi.py, change manage.py, upgrade `slugify` import, upgrade url conf import
8. Fix os.path.normpath import
9. Use paginator module for finding "next" or "prev" objects in Revision, Submission module
10. Make UserProfile model compatible with django-1.5

[5] Django transaction middleware raises https://github.com/scipy/SciPyCentral/issues/132

Note: A deprecation warning is observed when starting the server regarding `hashlib` import. This is caused in django transactions middleware (It will be deprecated in 1.7. However, we require it at the moment until we have our own Middleware)
