### PR TITLE
BUG: DVCSError Invalid signature on Windows platform

### DIFF
--- a/scipy_central/filestorage/dvcs_wrapper.py
+++ b/scipy_central/filestorage/dvcs_wrapper.py
@@ -121,9 +121,8 @@ class DVCSRepo(object):
 
         # Set home directory to here, to avoid using spurious
         # hgrc/gitconfig files
-        env = {
-            'HOME': os.path.abspath(os.path.dirname(__file__))
-        }
+        env = dict(os.environ)
+        env['HOME'] = os.path.abspath(os.path.dirname(__file__))
 
         try:
             command[0] = self.verbs[verb][0]


### PR DESCRIPTION
Bug: Unable to create snippet submissions (create a repo) on Windows platform
Exception raised: DVCSError;
Exception value: DVCS Command Failed 255: Invalid Signature

This change is tested on Ubuntu Linux platform and it was working.
