### PR TITLE
BUG: ignore exceptions in most_viewed template filter

### DIFF
--- a/scipy_central/submission/templatetags/core_tags.py
+++ b/scipy_central/submission/templatetags/core_tags.py
@@ -34,7 +34,6 @@ def top_authors(field, num=5):
     else:
         return entries
 
-
 @register.filter
 def most_viewed(field, num=5):
     """ Get the most viewed items from the Submission model """
@@ -42,10 +41,12 @@ def most_viewed(field, num=5):
     top_items.sort(reverse=True)
     out = []
     for score, pk in top_items[:num]:
-        out.append(Submission.objects.get(id=pk))
-        out[-1].score = score
+        try:
+            out.append(Submission.objects.get(pk=pk))
+            out[-1].score = score
+        except (Submission.DoesNotExist, IndexError):
+            pass
     return out
-
 
 @register.filter
 def cloud(model_or_obj, num=5):


### PR DESCRIPTION
`most_viewed()` template-filter search all `Submission` objects based on `pk` stored in `PageHit` objects. An exception is raised when the `Submission` object is not present in database but `PageHit` consists of its `pk` values.

`PageHit` model logs all data. So, the exceptions are ignored instead of deleting respective `PageHit` objects.
