### PR TITLE
BUG: correct next_revision, previous_revision methods

### DIFF
--- a/scipy_central/submission/models.py
+++ b/scipy_central/submission/models.py
@@ -282,28 +282,27 @@ class Revision(models.Model):
 
     @property
     def previous_revision(self):
-        all_revs = self.entry.revisions.absolutely_all().order_by('pk')
-        pages = Paginator(all_revs, 1)
-        current_page = pages.page(self.pk)
-        if current_page.has_previous():
-            rev = all_revs.get(
-                pk=current_page.previous_page_number
-            )
-            return rev
-        else:
+        all_revs = list(self.entry.revisions.absolutely_all())
+        try:
+            if all_revs.index(self)-1 >= 0:
+                return all_revs[all_revs.index(self)-1]
+            else:
+                return None
+        except ValueError:
+            # Happens when previewing a submission before submitting it
             return None
 
     @property
     def next_revision(self):
-        all_revs = self.entry.revisions.absolutely_all().order_by('pk')
-        pages = Paginator(all_revs, 1)
-        current_page = pages.page(self.pk)
-        if current_page.has_next():
-            rev = all_revs.get(
-                pk=current_page.next_page_number
-            )
-            return rev
-        else:
+        all_revs = list(self.entry.revisions.absolutely_all())
+        try:
+            if all_revs.index(self)+1 >= len(all_revs):
+                return None
+            else:
+                return all_revs[all_revs.index(self)+1]
+        except ValueError:
+            # Happens when previewing a submission before submitting it
+            # (the template calls on self.next_revision)
             return None
 
     @property


### PR DESCRIPTION
`Revision.next_revision` and `Revision.previous_revision` does not work correctly.

The methods implementation is particularly reverted as in previous

Bug raised at: 35f3395c2eaf149e4d2392606a24ac237a753c26
Previous implementation can be found at: d9f6a859d726b164e584047c3436d89c2ae54c79
