### PR TITLE
Change upload image button design

### DIFF
--- a/scipy_central/submission/templates/submission/new-item.html
+++ b/scipy_central/submission/templates/submission/new-item.html
@@ -111,21 +111,16 @@ $(function() {
 						    <div class="alert alert-error hide" data-resp="server-error"><b>Server Error</b>, Please try again later</div>
 						</div>
 					</div>
+					<div style="border-style:solid; border-width:1px; border-radius: 4px; border-color:#cccccc">
+						Attach <a href="#image_upload-modal" data-toggle="modal">image</a> to your description <i class="icon-question-sign" onclick="$('#alert-image_upload').toggle();"></i>
+						<div class="alert alert-info help-text" id="alert-image_upload" style="display: none;">
+							<div class="close" onclick="$('#alert-image_upload').hide();">&times;</div>
+							<p><small>Please upload JPEG or PNG images. Please refer to <a href="{% url spc-markup-help %}" target="_blank">markup</a> for adding images in the description</small></p>
+						</div>
+					</div>
 				{% else %}
 					{{field|add_class:"span12"|safe}}
 				{% endif %}
-			</div>
-		</div>
-	{% endif %}
-	{% if field.name == 'description' %}
-		<div class="control-group no-lead">
-			<label class="control-label"><b>ADD AN IMAGE OR SCREENSHOT</b> TO YOUR SUBMISSION (OPTIONAL) <i class="icon-question-sign" onclick="$('#alert-image_upload').toggle();"></i></label>
-			<div class="controls">
-				<div class="alert alert-info help-text" id="alert-image_upload" style="display: none;">
-					<div class="close" onclick="$('#alert-image_upload').hide();">&times;</div>
-					<p><small>Please upload JPEG or PNG images. Please refer to <a href="{% url spc-markup-help %}" target="_blank">markup</a> for adding images in the description</small></p>
-				</div>
-				<a href="#image_upload-modal" role="button" class="btn btn-primary btn-small" data-toggle="modal">Upload Image</a>
 			</div>
 		</div>
 	{% endif %}


### PR DESCRIPTION
Upload image link is previously shown by using a "button" typically, as a separate field in the submission form. However, the upload-image field is a substitute to add images in description.

This image button is changed to a text link written at the bottom of text editor as shown below

![upload-img-preview](https://cloud.githubusercontent.com/assets/932927/2944704/fdabad30-d9d7-11e3-9371-bf9679cf3f89.jpg)
