### PR TITLE
Fix select file button

### DIFF
--- a/scipy_central/submission/templates/submission/new-item.html
+++ b/scipy_central/submission/templates/submission/new-item.html
@@ -160,8 +160,7 @@ $(document).ready(function() {
 			<h3 id="myModalLabel">Upload image(s) here to add in description</h3>
 		</div>
 		<div class="modal-body">
-			<input style="visibility: hidden;" id="image_upload-file" type="file" placeholder="Choose" name="spc_image_upload">
-			<div class="btn btn-primary pull-left" onclick="document.getElementById('image_upload-file').click(); return false;">Choose File</div>
+			<input type="file" placeholder="Choose" name="spc_image_upload">
 			<p class="text-info no-lead" id="spc-item-upload-output-ajax-adds-it"></p>
 		</div>
 		<div class="modal-footer">


### PR DESCRIPTION
The tweaked select-file button in submission form does not display file name after selected.
This could be best replaced by default button provided by browsers!
