### PR TITLE
BUG: remove hardcode domain name in image URL

### DIFF
--- a/deploy/urls.py
+++ b/deploy/urls.py
@@ -22,4 +22,6 @@ if settings.DEBUG:
         '',
         (r'^static/(?P<path>.*)$',
          'django.views.static.serve', {'document_root': settings.STATIC_ROOT}),
+        (r'^media/(?P<path>.*)$',
+         'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
     )

--- a/scipy_central/rest_comments/sphinx-conf.py
+++ b/scipy_central/rest_comments/sphinx-conf.py
@@ -31,7 +31,7 @@ extlinks = {'id': ('http://scipy-central.org/item/%s', 'item #'),
 import sys, os
 sys.path.insert(0, os.path.abspath('.'))
 extensions.append('ext.images')
-ext_images = {'image': '{{FULL_MEDIA_URL}}images/%s'}
+ext_images = {'image': '/{{FULL_MEDIA_URL}}images/%s'}
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/scipy_central/rest_comments/views.py
+++ b/scipy_central/rest_comments/views.py
@@ -49,12 +49,7 @@ def setup_compile_dir(compile_dir):
     with file(conf_template_file, 'r') as f:
         conf_template = template.Template(f.read())
 
-    if settings.MEDIA_URL.startswith('http'):
-        conf = conf_template.render(template.Context({'FULL_MEDIA_URL':
-                                                      settings.MEDIA_URL}))
-    else:
-        conf = conf_template.render(template.Context({'FULL_MEDIA_URL':
-                                                      site + settings.MEDIA_URL}))
+    conf = conf_template.render(template.Context({'FULL_MEDIA_URL': settings.MEDIA_URL}))
 
     with file(conf_file, 'w') as f:
         f.write(conf)


### PR DESCRIPTION
Changes:

1. Remove hardcoded domain-name of image URLs in HTML when converted from ReST
2. Serve media files under development server

Description: 

Previously, image URLs in HTML are in format: `http://scipy-central.org/{{MEDIA_URL}}/{{IMAGE_URL}}/`. Now, image URLs in HTML are in format: `/{{MEDIA_URL}}/{{IMAGE_URL}}/` (domain name is not needed for modern browsers)

NOTE: `{{MEDIA_URL}}` if changed in `settings.py` needs maintenance work to recompile stored links in submissions' description!