### PR TITLE
BUG: correct invalid os name

### DIFF
--- a/scipy_central/filestorage/dvcs_wrapper.py
+++ b/scipy_central/filestorage/dvcs_wrapper.py
@@ -88,7 +88,7 @@ class DVCSRepo(object):
             if os.name == 'posix':
                 self.executable = search_file(self.backend,
                                               os.environ['PATH'])
-            elif os.name == 'windows':
+            elif os.name == 'nt':
                 self.executable = search_file(self.backend + '.exe',
                                               os.environ['PATH'])
         if not self.executable:


### PR DESCRIPTION
os.name for Windows will be `nt` not `windows`

Reference: https://docs.python.org/2/library/os.html#os.name