### PR TITLE
ENH: increase extra_info length to 2083

### DIFF
--- a/scipy_central/pagehit/migrations/0003_auto__chg_field_pagehit_extra_info.py
+++ b/scipy_central/pagehit/migrations/0003_auto__chg_field_pagehit_extra_info.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'PageHit.extra_info'
+        db.alter_column('pagehit_pagehit', 'extra_info', self.gf('django.db.models.fields.CharField')(max_length=2083, null=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'PageHit.extra_info'
+        db.alter_column('pagehit_pagehit', 'extra_info', self.gf('django.db.models.fields.CharField')(max_length=512, null=True))
+
+    models = {
+        'pagehit.pagehit': {
+            'Meta': {'object_name': 'PageHit'},
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'extra_info': ('django.db.models.fields.CharField', [], {'max_length': '2083', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.IPAddressField', [], {'max_length': '15'}),
+            'item': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'item_pk': ('django.db.models.fields.IntegerField', [], {}),
+            'ua_string': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['pagehit']

--- a/scipy_central/pagehit/models.py
+++ b/scipy_central/pagehit/models.py
@@ -23,11 +23,22 @@ class PageHit(models.Model):
     datetime = models.DateTimeField(auto_now=True)
     item = models.CharField(max_length=50)
     item_pk = models.IntegerField()
-    extra_info = models.CharField(max_length=512, null=True, blank=True)
+
+    # Support the length at most 2083, the max URL limit in IE or 
+    # usual search index limit
+    extra_info_len = 2083
+    extra_info = models.CharField(max_length=extra_info_len, null=True, blank=True)
 
     def __unicode__(self):
         return '%s at %s' % (self.item, self.datetime)
 
+    def save(self, *args, **kwargs):
+        """
+        Truncate `extra_info` if it exceeds
+        """
+        if isinstance(self.extra_info, str) and len(self.extra_info) > self.extra_info_len:
+            self.extra_info = self.extra_info[:self.extra_info_len]
+        super(PageHit, self).save(*args, **kwargs)
 
     def most_viewed(self, field):
         """ Most viewed in terms of a certain item.


### PR DESCRIPTION
Increase extra_info field to 2083, the max limit of URL in IE, and usual search engine index limit.

Truncate if extra_info coming from HTTP_REFERER exceeds 2083.